### PR TITLE
Bullying press release fixes

### DIFF
--- a/bullying/about/pressrelease.asp
+++ b/bullying/about/pressrelease.asp
@@ -117,7 +117,7 @@ Set FSO = nothing
  
 <br class="clearfloat" />
  
+<!--#include virtual="/bullying/templates/footer.asp"-->
  <!-- end .content --></div>
 <!-- ########################## END MAIN CONTENT ########################################### -->
-<!--#include virtual="/bullying/templates/footer.asp"-->
 

--- a/bullying/about/pressrelease.asp
+++ b/bullying/about/pressrelease.asp
@@ -4,8 +4,8 @@
 <meta name="description" content="" />
 <title>National Bullying Prevention Center - Pressroom</title>
 
-<meta property="og:title" content="" />
-<meta property="og:url" content="" />
+<meta property="og:title" content="National Bullying Prevention Center - Pressroom" />
+<meta property="og:url" content="http://www.pacer.org/bullying/about/pressrelease.asp?file=<%=Request.QueryString("file")%>" />
 <meta property="og:image" content="http://www.pacer.org/bullying/nbpm/images/unityDay-fb.jpg" />
 <meta property="og:description" content="" />
 </head>


### PR DESCRIPTION
* Adds the `og:title` and `og:url` meta values.
* Fixes the footer layout.

Footer before:

![-users-thofmann-projects-pacer-amex-disney-completed-pages-bullying-about-pressrelease html 1](https://user-images.githubusercontent.com/5055041/31193797-21e8008c-a913-11e7-9c7c-da3a85b61d30.png)

Footer after:

![-users-thofmann-projects-pacer-amex-disney-completed-pages-bullying-about-pressrelease html](https://user-images.githubusercontent.com/5055041/31193803-25876188-a913-11e7-9ad7-88508846e959.png)