### PR TITLE
Fixes for: http://www.pacer.org/bullying/classroom/elementary/activities

### DIFF
--- a/bullying/classroom/elementary/activities/index.asp
+++ b/bullying/classroom/elementary/activities/index.asp
@@ -23,8 +23,11 @@
  		margin-top:-95px;
  	}
     @media (max-width: 1000px) {
-    #studentsteachingstudents{
-        margin-top: 0;
+        #studentsteachingstudents{
+            margin-top: 0;
+        }
+        #activitestable img {
+            display: none;
         }
     }
  </style>

--- a/bullying/classroom/elementary/activities/index.asp
+++ b/bullying/classroom/elementary/activities/index.asp
@@ -22,6 +22,11 @@
  	#studentsteachingstudents{
  		margin-top:-95px;
  	}
+    @media (max-width: 1000px) {
+    #studentsteachingstudents{
+        margin-top: 0;
+        }
+    }
  </style>
 </head>
 <body class="twocol">
@@ -29,12 +34,12 @@
 <a id="skiptocontent" href="#maincontent">Skip to main content</a>
 
 <!--#include virtual="/bullying/templates/page-header-nav.asp"-->
- 
+
 <div class="breadcrumb"> <a href="/bullying/">Home</a> / <a href="/bullying/classroom/">Classroom</a> / <a href="/bullying/classroom/elementary/">Elementary School</a></div>
- 
+
  <!-- ######################### NAVIGATION ################################# -->
-   <div class="sidebar1"> 
-  <!--#include virtual="/bullying/classroom/nav.html"--> 
+   <div class="sidebar1">
+  <!--#include virtual="/bullying/classroom/nav.html"-->
  <script type="text/javascript">
 	// ID and SubId to be Orange
 	var currId="ele-activities";
@@ -51,20 +56,20 @@
 			}
 		}
 	}
-</script> 
+</script>
  </div>
  <!-- ###################### END Navigation ############################## -->
- 
- <div class="content"> 
+
+ <div class="content">
   <h1 id="maincontent">Activities for Youth</h1>
-	
+
   <div class="alertBox" id="studentsteachingstudents">
 		<h3><strong><a href="/bullying/wewillgen/classroom-activities.asp">Students Teaching Students</a></strong></h3>
 		<p>Students &mdash; and educators &mdash; can use one or more of these activities from PACER&rsquo;s WE WILL Generation program for older students to educate younger students on topics such as defining bullying, individuality, and supporting each other. </p>
 	</div>
-	
+
 	<p>These free activities and resources are designed for younger students. The goal is to start conversation and creatively engage students to build their understanding of how to prevent bullying. </p>
-    
+
 <table id="activitestable" cellspacing="5">
 	<tr>
 		<td><img src="/bullying/resources/toolkits/activities/images/KABPledge_thumb.jpg" alt="" width="200" height="155" /></td>
@@ -85,12 +90,12 @@
 		<td><img src="/bullying/classroom/elementary/activities/images/kab-newsletter-thumb.jpg" alt="" /></td>
 		<td><h2><a href="/bullying/classroom/elementary/activities/kab-newsletter.asp">Kids Against Bullying Newsletter</a></h2>
 			<p>Download and share in classrooms and libraries. Involve your friends, teachers, coaches, and parents, and unite for kindness, acceptance, and inclusion!</p></td>
-		</tr>		
+		</tr>
         <tr>
 		<td><img src="/bullying/resources/toolkits/activities/images/poster_thumb.jpg" alt="" /></td>
 		<td><h2><a href="/bullying/classroom/elementary/activities/poster.asp">Create a Poster</a></h2>
 			<p>Send us your story, poem, artwork or video on the topic&nbsp;expressing your ideas on bullying prevention. It can be about what happened to you or someone else, how you feel about bullying, how you think it affects students and schools, what you have done to prevent bullying, or what others can do to prevent bullying. We want to hear from everyone&mdash;teens, parents, teachers, and others with great ideas who want to improve the world.</p></td>
-		</tr>		
+		</tr>
 		<tr>
 		<td><img src="/bullying/resources/toolkits/activities/images/stickpuppet_thumb.jpg" alt="" /></td>
 		<td><h2><a href="/bullying/classroom/elementary/activities/stick-puppet.asp">Stick Puppet Role Plays </a></h2>
@@ -109,29 +114,29 @@
         <tr>
 		<td><img src="/bullying/resources/toolkits/activities/images/unity-banner_thumb.jpg" alt="" /></td>
 		<td><h2>Unity Banner</h2>
-			
+
 						<p>Create a huge banner with the word UNITY  as the central theme. Ask everyone to make a voluntary contribution to sign  the banner, define what unity means to them, or make a suggestion about ways  to unite as a school or organization. This can be done on Unity Day or  anytime during the year.
 	</p>
 				</td>
 		</tr>
- 
+
 		  <td><img src="/bullying/resources/toolkits/activities/images/wrinkled-heart-thumb.jpg" alt="" /></td>
 		<td><h2><a href="/bullying/resources/toolkits/activities/wrinkled-heart.asp">A Wrinkled Heart</a></h2>
-			
+
 						<p>Designed for younger students, &ldquo;A Wrinkled Heart&rdquo; activity provides students with a powerful visual that shows the effects hurtful words or behaviors have on someone. The activity is simple and a great reminder to be kind to others.</p>
 				</td>
 		</tr>
-</table>	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+</table>
+
+
+
+
+
+
+
+
+
+
 <p><strong>Want more?</strong> -- Check out over a dozen <a href="/bullying/resources/toolkits/">Educator Toolkits</a> with activities designed for the classroom, community, and toolkits designed by students for students.</p>
 <!-- ########################## END MAIN CONTENT ########################################### -->
 <!--#include virtual="/bullying/templates/footer.asp"-->


### PR DESCRIPTION
* Move alert down when header would overlap it
* Hide activity book images when they would be too small

Before:

![before](https://user-images.githubusercontent.com/5055041/31836418-35a1bfb8-b5a3-11e7-9e14-058472d25057.png)

After:

![after](https://user-images.githubusercontent.com/5055041/31836420-38c9b510-b5a3-11e7-9062-c3c3a0540883.png)
